### PR TITLE
moves from GitHub to S3 source

### DIFF
--- a/codepipeline.yml
+++ b/codepipeline.yml
@@ -18,9 +18,6 @@ Parameters:
     Default: master
     Description: The branch for the GitHub repository
     Type: String
-  GitHubOAuthToken:
-    Description: The OAuth token to access GitHub
-    Type: String
   Email:
     Description: The email address where CodePipeline sends pipeline notifications
     Type: String
@@ -38,7 +35,6 @@ Metadata:
           - GitHubOwner
           - GitHubRepo
           - GitHubRepoBranch
-          - GitHubOAuthToken
       - Label:
           default: "Notifcation Settings"
         Parameters:
@@ -94,14 +90,12 @@ Resources:
             - Name: AppSource
               ActionTypeId:
                 Category: Source
-                Owner: ThirdParty
-                Provider: GitHub
+                Owner: AWS
+                Provider: S3
                 Version: '1'
               Configuration:
-                Owner: !Ref GitHubOwner
-                Repo: !Ref GitHubRepo
-                Branch: !Ref 'GitHubRepoBranch'
-                OAuthToken: !Ref 'GitHubOAuthToken'
+                S3Bucket: !ImportValue 'github-to-s3-outputbucket'
+                S3ObjectKey: !Sub '${GitHubOwner}/${GitHubRepo}/${GitHubOwner}_${GitHubRepo}.zip'
               OutputArtifacts:
                 - Name: AppSource
               RunOrder: '1'


### PR DESCRIPTION
This allows the stack to integrate with the `mozilla-iam/aws-github-to-s3` project. That project creates a stack export of the S3 bucket used to store cloned repositories after changes are detected. This PR allows us to watch for changes to the relevant files:

```
S3Bucket: !ImportValue 'github-to-s3-outputbucket'
S3ObjectKey: !Sub '${GitHubOwner}/${GitHubRepo}/${GitHubOwner}_${GitHubRepo}.zip'
```

Using a GitHub source is fantastic but we wanted to be able to use a webhook rather than polling. This also allows us to trigger builds off of arbitrary branches rather than having a 1:1 relationship of CodePipelines and branches.